### PR TITLE
Updated get_endpoint_url to url decode the url fragment before trying…

### DIFF
--- a/pubs_ui/tests/test_utils.py
+++ b/pubs_ui/tests/test_utils.py
@@ -19,6 +19,7 @@ class GetUrlEndpointTestCase(TestCase):
     def test_with_default_wsgi_str(self):
         self.assertEqual(get_url_endpoint('/contact', '127.0.0.1', self.fallback), ('pubswh.contact', {}))
         self.assertEqual(get_url_endpoint('/wsgi/test/contact', '127.0.0.1', self.fallback), ('pubswh.contact', {}))
+        self.assertEqual(get_url_endpoint('%2Fwsgi%2Ftest%2Fcontact', '127.0.0.1', self.fallback), ('pubswh.contact', {}))
 
     def test_with_user_wsgi_str(self):
         self.assertEqual(get_url_endpoint('/wsgi/test2/contact', '127.0.0.1', self.fallback, '/wsgi/test2'), ('pubswh.contact', {}))

--- a/pubs_ui/utils.py
+++ b/pubs_ui/utils.py
@@ -1,6 +1,6 @@
 
-import sys
 from urlparse import urlparse, urljoin
+from urllib import unquote
 
 from werkzeug.exceptions import NotFound, MethodNotAllowed
 
@@ -17,7 +17,9 @@ def get_url_endpoint(url, server_name, fallback, wsgi_str=None):
     '''
     if not wsgi_str:
         wsgi_str = app.config['WSGI_STR']
-    this_rule = url.replace(wsgi_str, '')
+    app.logger.info('Decoded url ' + unquote(url))
+    this_rule = unquote(url).replace(wsgi_str, '')
+    app.logger.info('Rule is ' + this_rule)
 
     try:
         ma = app.url_map.bind(server_name)


### PR DESCRIPTION
… to find it's endpoint. Added a test to match the conditions we see when external URLs are used.