### PR TITLE
Needed to back lxml to 3.4.4 from 3.5.0 as it was raing a TypeError w…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ fuzzywuzzy==0.8.0
 httpretty==0.8.12
 itsdangerous==0.24
 lettuce==0.2.21
-lxml==3.5.0
+lxml==3.4.4
 marshmallow==2.4.2
 mock==1.3.0
 natsort==4.0.4


### PR DESCRIPTION
…hen python 2.7.10 was used.