### PR TITLE
Fix lettuces2

### DIFF
--- a/pubs_ui/lettuce_testing/features/test_utils.py
+++ b/pubs_ui/lettuce_testing/features/test_utils.py
@@ -675,7 +675,6 @@ def step_impl(step):
     :type step lettuce.core.Step
 
     """
-    print world.munged_abstract_result
     assert_items_equal(world.munged_abstract_result, world.munged_abstract_result_expected)
 
 

--- a/pubs_ui/lettuce_testing/features/test_utils.py
+++ b/pubs_ui/lettuce_testing/features/test_utils.py
@@ -1,5 +1,5 @@
 import httpretty
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_items_equal
 from lettuce import *
 import json
 from requests import get
@@ -673,8 +673,10 @@ def step_impl(step):
 def step_impl(step):
     """
     :type step lettuce.core.Step
+
     """
-    assert_equal(world.munged_abstract_result, world.munged_abstract_result_expected)
+    print world.munged_abstract_result
+    assert_items_equal(world.munged_abstract_result, world.munged_abstract_result_expected)
 
 
 @step("I have a mocked base publication record that has a populated interactions data element, a base url, and a mocked legacy endpoint")

--- a/pubs_ui/manager/static/js/models/PublicationCollection.js
+++ b/pubs_ui/manager/static/js/models/PublicationCollection.js
@@ -25,7 +25,6 @@ define([
 		// maps the query parameters accepted by service to `state` keys
 		// to those your server supports
 		queryParams: {
-			currentPage: "page_number",
 			pageSize:  "page_size"
 		},
 

--- a/pubs_ui/pubswh/utils.py
+++ b/pubs_ui/pubswh/utils.py
@@ -733,7 +733,7 @@ def munge_abstract(pubdata):
     """
     if pubdata.get('docAbstract') is not None:
         abstract = deepcopy(pubdata['docAbstract'])
-        soup = BeautifulSoup(abstract, "lxml-xml")
+        soup = BeautifulSoup(abstract, "lxml")
         #find the h1 tag
         if soup.find('h1') is not None:
             possible_header = soup.find('h1').contents[0]

--- a/pubs_ui/pubswh/utils.py
+++ b/pubs_ui/pubswh/utils.py
@@ -261,7 +261,7 @@ def pull_feed(feed_url):
     # Process html to remove unwanted mark-up and fix links
     post = ''
     if len(feed['entries']) > 0:
-        soup = BeautifulSoup(feed['entries'][0].summary)
+        soup = BeautifulSoup(feed['entries'][0].summary, 'lxml')
 
         # Remove edited by paragraph
         soup.p.extract()
@@ -288,7 +288,7 @@ def getbrowsecontent(browseurl, browsereplace):
     :return: html content of links, breadcrumb, and title
     """
     content = requests.get(browseurl, verify=verify_cert)
-    soup = BeautifulSoup(content.text)
+    soup = BeautifulSoup(content.text, 'lxml')
     for a in soup.findAll('a'):
         a['href'] = a['href'].replace("browse", browsereplace)
     browse_content = {'links': soup.find('div', {"id": "pubs-browse-links"}).contents,
@@ -733,7 +733,7 @@ def munge_abstract(pubdata):
     """
     if pubdata.get('docAbstract') is not None:
         abstract = deepcopy(pubdata['docAbstract'])
-        soup = BeautifulSoup(abstract, "html.parser")
+        soup = BeautifulSoup(abstract, "lxml-xml")
         #find the h1 tag
         if soup.find('h1') is not None:
             possible_header = soup.find('h1').contents[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ redis==2.10.5
 requests==2.9.1
 six==1.10.0
 sure==1.2.24
-unittest2==1.1.0
 testtools==1.8.1
 traceback2==1.4.0
 urllib3==1.13.1


### PR DESCRIPTION
Trying to get the tests to run on 2.7.11 on the Jenkins server. BeautifulSoup now contains a parser arguments which is defaulted if not specified. We are not specifying it to use lxml. Also removed unittest2 from requirements as it is not needed and all functionality in it is in unittest in 2.7.11. Note that I had to fix an assert where dictionaries were compared to use assert_items_equal rather than assert. This compares the dictionaries without requiring that the order be the same.