### PR TITLE
Reverted change to registering metrics blueprint. Instead, handle the…

### DIFF
--- a/pubs_ui/__init__.py
+++ b/pubs_ui/__init__.py
@@ -53,13 +53,10 @@ import assets
 from auth.views import auth
 from manager.views import manager
 from pubswh.views import pubswh
+from metrics.views import metrics
 
 app.register_blueprint(auth)
-app.register_blueprint(manager,
-                       url_prefix='/manager')
-if (app.config.get('GA_KEY_FILE_PATH')):
-    from metrics.views import metrics
-    app.register_blueprint(metrics, url_prefix='/metrics')
-#app.register_blueprint(metrics, url_prefix='/metrics')
+app.register_blueprint(manager, url_prefix='/manager')
+app.register_blueprint(metrics, url_prefix='/metrics')
 app.register_blueprint(pubswh)
 

--- a/pubs_ui/metrics/views.py
+++ b/pubs_ui/metrics/views.py
@@ -18,12 +18,13 @@ metrics = Blueprint('metrics', __name__,
                     static_url_path='/metrics/static')
 
 verification_cert = app.config.get('VERIFY_CERT', True)
-
-credentials = ServiceAccountCredentials.from_json_keyfile_name(
-      app.config.get('GA_KEY_FILE_PATH'),
-      app.config.get('GA_OAUTH2_SCOPE'))
-analytics = build('analytics', 'v4', http=credentials.authorize(Http()), discoveryServiceUrl=app.config.get('GA_DISCOVERY_URI'))
-
+try:
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(
+          app.config.get('GA_KEY_FILE_PATH'),
+          app.config.get('GA_OAUTH2_SCOPE'))
+    analytics = build('analytics', 'v4', http=credentials.authorize(Http()), discoveryServiceUrl=app.config.get('GA_DISCOVERY_URI'))
+except IOError:
+    credentials = None
 
 def get_access_token():
     if isinstance(verification_cert, str):


### PR DESCRIPTION
… IOError if the keyfile is missing.