### PR TITLE
Add display title field to Pubs Warehouse UI.

### DIFF
--- a/pubs_ui/manager/static/js/hb_templates/bibliodata.hbs
+++ b/pubs_ui/manager/static/js/hb_templates/bibliodata.hbs
@@ -62,6 +62,13 @@
 			<input id="subchapter-input" type="text" class="form-control"/>
 		</div>
 	</div>
+	<div class="form-group" id="displayTitle-div">
+		<label class="control-label" for="display-title-input">Display Title</label>
+
+		<div>
+			<input id="display-title-input" type="text" class="form-control"/>
+		</div>
+	</div>
 	<div class="form-group" id="title-div">
 		<label class="control-label" for="title-input">Title</label>
 

--- a/pubs_ui/manager/static/js/views/BibliodataView.js
+++ b/pubs_ui/manager/static/js/views/BibliodataView.js
@@ -42,6 +42,7 @@ define([
 			'#series-number-input' : 'seriesNumber',
 			'#chapter-input' : 'chapter',
 			'#subchapter-input' : 'subchapterNumber',
+			'#display-title-input' : 'displayTitle',
 			'#title-input' : 'title',
 			'#usgs-citation-input' : 'usgsCitation',
 			'#collaboration-input' : 'collaboration',

--- a/pubs_ui/pubswh/templates/pubswh/publication.html
+++ b/pubs_ui/pubswh/templates/pubswh/publication.html
@@ -70,8 +70,14 @@
             {% else %}
                 {{ thumbnail_image() }}
             {% endif %}
+
+                {# Choose publication title information to be displayed #}
                 <hgroup class="publicationTitle">
+                    {% if pubdata['displayTitle'] %}
+                    <h3 itemprop="name">{{ pubdata['displayTitle']|safe }}</h3>
+                    {% else %}
                     <h3 itemprop="name">{{ pubdata['title']|safe }}</h3>
+                    {% endif %}
                     {% if pubdata['seriesTitle'] %}
                     <h4>{{ pubdata['seriesTitle']['text'] }} {{ pubdata['seriesNumber'] }}{% if pubdata['chapter'] %}-{{ pubdata['chapter'] }}{% endif %}{% if pubdata['subChapter'] %}-{{ pubdata['subChapter'] }}{% endif %}</h4>
                     {% endif %}


### PR DESCRIPTION
Added display title field to the Pubs Warehouse UI project.  The display title will display for a any given publication if a display title is associated with that publication.  Otherwise It will default to the title.  The display title will also be added to the manager application as an editable field.

Related back end pubs services pull requests:
-https://internal.cida.usgs.gov/stash/projects/PUBS/repos/pubs-services/pull-requests/280/overview
-https://internal.cida.usgs.gov/stash/projects/PUBS/repos/pubs-services/pull-requests/281/overview

JIRA ticket for this task:
-https://internal.cida.usgs.gov/jira/browse/PUBSTWO-1251

Related back end JIRA task:
https://internal.cida.usgs.gov/jira/browse/PUBSTWO-1509
