### PR TITLE
PUBSTWO-1568 Fix

### DIFF
--- a/server/pubs_ui/pubswh/templates/pubswh/publication.html
+++ b/server/pubs_ui/pubswh/templates/pubswh/publication.html
@@ -321,8 +321,8 @@
                     <h4 id="" class="dark">Additional publication details</h4>
                     <dl id="publication_details">
                       {% for detail in pubdata['details'] %}
-                          <dt class="{{ loop.cycle('', 'dark') }}">{{ detail.keys()[0] }}</dt>
-                          <dd class="{{ loop.cycle('', 'dark') }}">{{ detail.values()[0]|safe }}</dd>
+                          <dt class="{{ loop.cycle('', 'dark') }}">{{ detail.keys() | join(', ') }}</dt>
+                          <dd class="{{ loop.cycle('', 'dark') }}">{{ detail.values() | join(', ') | safe }}</dd>
                       {% endfor %}
                     </dl>
                 </section>


### PR DESCRIPTION
Bugfix: can't subscript dict iterators in Python 3. Also can't convert an iterator to a list in with Jinja2. So hack: join one-length iterators.