### PR TITLE
Code split fixes

### DIFF
--- a/assets/rollup.config.js
+++ b/assets/rollup.config.js
@@ -28,12 +28,7 @@ const getBundleConfig = function (output) {
 
 module.exports = [
     getBundleConfig({
-        dir: 'dist/scripts/module',
-        format: 'es',
-        sourcemap: ENV !== 'production'
-    }),
-    getBundleConfig({
-        dir: 'dist/scripts/nomodule',
+        dir: 'dist/scripts',
         format: 'system',
         sourcemap: ENV !== 'production'
     })

--- a/server/pubs_ui/templates/assets.html
+++ b/server/pubs_ui/templates/assets.html
@@ -1,9 +1,28 @@
 {% macro LoadBundle(bundle) -%}
     <script type='module'>
         import('{{ ("scripts/module/" + bundle) | asset_url }}');
+        window.hasDynamicImport = true;
     </script>
     <script nomodule src="{{ 'vendor/system.js' | asset_url }}"></script>
     <script nomodule>
         System.import('{{ ("scripts/nomodule/" + bundle) | asset_url }}');
+    </script>
+    <!-- nomodule fallback: modules, no dynamic import -->
+    <script type="module">
+        if (!window.hasDynamicImport) {
+            const noms = Array.prototype.filter.call(document.getElementsByTagName('script'), x => x.hasAttribute('nomodule'));
+            function nextLoad (nom, s) {
+                if (!(nom = noms.shift())) return;
+                s = document.createElement('script');
+                if (nom.src) {
+                    s.src = nom.src, s.addEventListener('load', nextLoad), s.addEventListener('error', nextLoad);
+                } else {
+                    s.innerHTML = nom.innerHTML;
+                }
+                document.head.appendChild(s);
+                if (!nom.src) nextLoad();
+            }
+            nextLoad();
+        }
     </script>
 {%- endmacro %}

--- a/server/pubs_ui/templates/assets.html
+++ b/server/pubs_ui/templates/assets.html
@@ -1,28 +1,6 @@
 {% macro LoadBundle(bundle) -%}
-    <script type='module'>
-        import('{{ ("scripts/module/" + bundle) | asset_url }}');
-        window.hasDynamicImport = true;
-    </script>
-    <script nomodule src="{{ 'vendor/system.js' | asset_url }}"></script>
-    <script nomodule>
-        System.import('{{ ("scripts/nomodule/" + bundle) | asset_url }}');
-    </script>
-    <!-- nomodule fallback: modules, no dynamic import -->
-    <script type="module">
-        if (!window.hasDynamicImport) {
-            const noms = Array.prototype.filter.call(document.getElementsByTagName('script'), x => x.hasAttribute('nomodule'));
-            function nextLoad (nom, s) {
-                if (!(nom = noms.shift())) return;
-                s = document.createElement('script');
-                if (nom.src) {
-                    s.src = nom.src, s.addEventListener('load', nextLoad), s.addEventListener('error', nextLoad);
-                } else {
-                    s.innerHTML = nom.innerHTML;
-                }
-                document.head.appendChild(s);
-                if (!nom.src) nextLoad();
-            }
-            nextLoad();
-        }
+    <script src="{{ 'vendor/system.js' | asset_url }}"></script>
+    <script>
+        SystemJS.import('{{ ("scripts/" + bundle) | asset_url }}');
     </script>
 {%- endmacro %}


### PR DESCRIPTION
On the ES builds, minification (with multiple methods) appears to cause some code to be removed or become inaccessible on a couple of the bundles. Rather than spend much time debugging, this will just use SystemJS to load the modules on all browsers. Works for me on latest Firefox, Safari, and Chrome.