### PR TITLE
Load createResultsMap from SystemJS-returned module

### DIFF
--- a/assets/scripts/pubswh/resultsMap.js
+++ b/assets/scripts/pubswh/resultsMap.js
@@ -12,7 +12,7 @@ import popupTemplate from './hb_templates/resultsMapPopup.hbs';
  *      @prop {Boolean} enablePopup - publication extent layers should be interactive only when set to true
  * @returns {L.Map} - Returns the map object created.
  */
-export const createResultsMap = window.createResultsMap = function(options) {
+export const createResultsMap = function(options) {
     /*var EMPTY_PUBS_EXTENTS = {
         type: 'FeatureCollection',
         features: [],

--- a/server/pubs_ui/pubswh/templates/pubswh/base.html
+++ b/server/pubs_ui/pubswh/templates/pubswh/base.html
@@ -13,6 +13,7 @@
         <meta name="format-detection" content="telephone=no">
         {% block head %} {% endblock %}
         {% block page_style %}{% endblock page_style %}
+        <script src="{{ 'vendor/system.js' | asset_url }}"></script>
         <link rel="stylesheet" href="{{ 'pubs_base.css' | asset_url }}" type="text/css" />
         <link rel="shortcut icon" href="{{ 'images/pubswh/favicon.ico' | asset_url }}"/>
         <link rel="search" type="application/opensearchdescription+xml" href="{{ url_for('pubswh.open_search') }}" title="USGS Pubs"/>

--- a/server/pubs_ui/pubswh/templates/pubswh/publication.html
+++ b/server/pubs_ui/pubswh/templates/pubswh/publication.html
@@ -358,15 +358,14 @@
             {%- if pubdata["geographicExtents"] -%}
                 <script type="text/javascript" src="{{ 'vendor/leaflet/leaflet.js' | asset_url }}"></script>
                 <script type="text/javascript" src="{{ 'vendor/esri-leaflet/esri-leaflet.js' | asset_url }}"></script>
-                {{ assets.LoadBundle('resultsMap.js') }}
-
                 <script type="application/javascript">
-                    window.createResultsMap({
-                        mapDivId: 'mymap',
-                        publications: [{{ pubdata | tojson | safe }}],
-                        enablePopup: false
+                    SystemJS.import('{{ "scripts/resultsMap.js" | asset_url }}').then(function (resultsMap) {
+                        resultsMap.createResultsMap({
+                            mapDivId: 'mymap',
+                            publications: [{{ pubdata | tojson | safe }}],
+                            enablePopup: false
+                        });
                     });
                 </script>
             {% endif %}
         {% endblock page_footer_script %}
-

--- a/server/pubs_ui/templates/assets.html
+++ b/server/pubs_ui/templates/assets.html
@@ -1,5 +1,4 @@
 {% macro LoadBundle(bundle) -%}
-    <script src="{{ 'vendor/system.js' | asset_url }}"></script>
     <script>
         SystemJS.import('{{ ("scripts/" + bundle) | asset_url }}');
     </script>

--- a/server/pubs_ui/templates/base.html
+++ b/server/pubs_ui/templates/base.html
@@ -7,6 +7,7 @@
         {% block meta_data %}{% endblock %}
 
         <title>{% block title %}USGS Publications Warehouse{% endblock %}</title>
+        <script src="{{ 'vendor/system.js' | asset_url }}"></script>
         {% block page_style %}
             <link rel="stylesheet" href="{{ 'usgs_style.css' | asset_url }}" type="text/css" />
         {% endblock %}


### PR DESCRIPTION
Load createResultsMap from SystemJS-returned module; move system.js script tag to base.html templates to avoid it being evaluated more than once.