### PR TITLE
pubs-1614 - The author filter isn't quite working

### DIFF
--- a/assets/scripts/manager/utils/DynamicSelect2.js
+++ b/assets/scripts/manager/utils/DynamicSelect2.js
@@ -57,7 +57,6 @@ import isFunction from 'lodash/isFunction';
         let lastResults = {};
 
         result.ajax.transport = function(params, success, failure) {
-            console.log('Params: ' + params.data.text);
             lastParams = params;
             let deferred = $.Deferred();
 
@@ -69,7 +68,6 @@ import isFunction from 'lodash/isFunction';
             });
 
             $.when(...subgroupRequests).always(function() {
-                console.log('in always Params: ' + params.data.text);
                 deferred.resolve([params].concat(Array.from(arguments)));
             });
             deferred.done(success).fail(failure);

--- a/assets/scripts/manager/utils/DynamicSelect2.js
+++ b/assets/scripts/manager/utils/DynamicSelect2.js
@@ -51,8 +51,16 @@ import isFunction from 'lodash/isFunction';
     // deferred which is resolved after both calls are done.
     if (has(options, 'subgroups') && has(options.subgroups, 'queryParameter') && has(options.subgroups, 'nameAndValues') &&
         options.subgroups.nameAndValues.length) {
+
+        // These are used to guarentee that the last ajax command started is shown in the select.
+        let lastParams = {};
+        let lastResults = {};
+
         result.ajax.transport = function(params, success, failure) {
+            console.log('Params: ' + params.data.text);
+            lastParams = params;
             let deferred = $.Deferred();
+
             let subgroupRequests = [];
             options.subgroups.nameAndValues.forEach((subgroup) => {
                 let data = clone(params.data);
@@ -61,24 +69,27 @@ import isFunction from 'lodash/isFunction';
             });
 
             $.when(...subgroupRequests).always(function() {
-                deferred.resolve(Array.from(arguments));
+                console.log('in always Params: ' + params.data.text);
+                deferred.resolve([params].concat(Array.from(arguments)));
             });
-            deferred.done(success);
-            deferred.fail(failure);
+            deferred.done(success).fail(failure);
 
-            return deferred;
+            return deferred.promise();
         };
         result.ajax.processResults = function(responses) {
-            let resultsData = [];
-            responses.forEach((resp, index) => {
-                resultsData.push({
-                    text: options.subgroups.nameAndValues[index].name,
-                    children: resp[0].slice(0, SUBGROUP_CHILDREN_LIMIT)
+            if (lastParams == responses[0]) {
+                let resultsData = [];
+                responses.slice(1).forEach((resp, index) => {
+                    resultsData.push({
+                        text: options.subgroups.nameAndValues[index].name,
+                        children: resp[0].slice(0, SUBGROUP_CHILDREN_LIMIT)
+                    });
                 });
-            });
-            return {
-                results: resultsData
-            };
+                lastResults = {
+                    results: resultsData
+                };
+            }
+            return lastResults;
         };
     } else {
         result.ajax.processResults = function(resp) {

--- a/assets/styles/pubswh/pubs_base.scss
+++ b/assets/styles/pubswh/pubs_base.scss
@@ -12,7 +12,9 @@ $fa-font-path: "./fonts" !default;
 
 @import '../../node_modules/select2-bootstrap-theme/src/select2-bootstrap.scss';
 
-
+h6 {
+  text-transform: none;
+}
 // Overrides to prevent conflicts between bootstrap and USWDS
 .select2-search input[type="search"] {
   float: none;


### PR DESCRIPTION
Since we redefine the ajax.transport option for dynamic selects with subgroups, we need to guarentee that the last ajax call is the one that updates the select, even when it returns before previous ajax calls.