### PR TITLE
Added new config parameter SECURE_COOKIES which defaults to True. In …

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -93,3 +93,6 @@ FLASK_CORS = False
 
 # To use hashed assets, set this to the gulp-rev-all rev-manifest.json path
 ASSET_MANIFEST_PATH = None
+
+# Set to False when running the development server on https
+SECURE_COOKIES = True

--- a/server/config.py.sample
+++ b/server/config.py.sample
@@ -46,6 +46,9 @@ STATIC_ROOT = 'http://localhost:9000'
 # when static assets are hosted on a different port than the Flask dev server.
 FLASK_CORS = True
 
+# Set to False when running the development server on https
+SECURE_COOKIES = False
+
 # To use hashed assets, set this to the gulp-rev-all rev-manifest.json path
 #ASSET_MANIFEST_PATH = None
 

--- a/server/pubs_ui/auth/views.py
+++ b/server/pubs_ui/auth/views.py
@@ -77,7 +77,7 @@ def authorize():
     token = oauth.pubsauth.authorize_access_token(verify=False)
 
     response = redirect(request.args.get('next'))
-    response.set_cookie('access_token', token.get('access_token'), secure=True)
+    response.set_cookie('access_token', token.get('access_token'), secure=app.config['SECURE_COOKIES'])
     session['access_token_expires_at'] = token.get('expires_at')
 
     return response

--- a/server/run.py
+++ b/server/run.py
@@ -6,12 +6,18 @@ if __name__ == '__main__':
     
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', '-ht', type=str)
+    parser.add_argument('--port', '-p', type=int)
     args = parser.parse_args()
     host_val = args.host
     if host_val is not None:
         host = host_val
     else:
         host = '127.0.0.1'
-    application.run(host=host, port=5050, threaded=True)
+
+    if args.port is None:
+        port = 5050
+    else:
+        port = args.port
+    application.run(host=host, port=port, threaded=True)
     # run from the command line as follows
     # python runserver.py -ht <ip address of your choice>


### PR DESCRIPTION
…development, if you are running the dev server on http then set this to False. Also added a --port parameter to run so that the development server can run on a port other than 5050.